### PR TITLE
Link and article fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "angular": "^1.6.2",
     "angular-bootstrap": "^0.12.2",
     "angular-ui-router": "1.0.0-beta.3",
-    "dg-angular-patternfly-accessible": "0.0.1",
+    "dg-angular-patternfly-accessible": "0.0.2",
     "patternfly": "^3.30.0"
   },
   "devDependencies": {

--- a/src/app/animals/article-sharks.html
+++ b/src/app/animals/article-sharks.html
@@ -1,7 +1,7 @@
 <div id="main" class="row">
   <div class="col-xs-12">
     <ol class="breadcrumb">
-      <li><a href="#">Back to Wild Animals</a></li>
+      <li><a ui-sref="app.wild-animals">Back to Wild Animals</a></li>
     </ol>
     <article class="">
       <header>

--- a/src/app/animals/article-summary.html
+++ b/src/app/animals/article-summary.html
@@ -2,7 +2,7 @@
   <div class="col-xs-12">
     <article class="">
       <header>
-        <h2><a href="#">10 Things You Should Never Throw Away</a></h2>
+        <h2><a ui-sref="app.article-full">10 Things You Should Never Throw Away</a></h2>
         <small>By Dave Roos</small>
       </header>
       <div class="">
@@ -11,7 +11,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">5 Futuristic Green Home Improvements</a></h2>
+        <h2><a ui-sref="app.article-full">5 Futuristic Green Home Improvements</a></h2>
         <small>By Blythe Copeland</small>
       </header>
       <div class="">
@@ -20,7 +20,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Energy-Saving Tips to Save Money and the Planet</a></h2>
+        <h2><a ui-sref="app.article-full">Energy-Saving Tips to Save Money and the Planet</a></h2>
         <small>By Blythe Copeland</small>
       </header>
       <div class="">
@@ -29,7 +29,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">5 Surprising Ways to Save Energy</a></h2>
+        <h2><a ui-sref="app.article-full">5 Surprising Ways to Save Energy</a></h2>
         <small>By Blythe Copeland</small>
       </header>
       <div class="">

--- a/src/app/animals/article-wolves.html
+++ b/src/app/animals/article-wolves.html
@@ -1,7 +1,7 @@
 <div id="main" class="row">
   <div class="col-xs-12">
     <ol class="breadcrumb">
-      <li><a href="#">Back to Pets</a></li>
+      <li><a ui-sref="app.pets">Back to Pets</a></li>
     </ol>
     <article class="">
       <header>

--- a/src/app/animals/endangered-species.html
+++ b/src/app/animals/endangered-species.html
@@ -3,7 +3,7 @@
     <h1>Pets</h1>
     <article class="">
       <header>
-        <h2><a href="#">Panda Populations Are Growing, But Their Habitat Remains at Risk</a></h2>
+        <h2><a ui-sref="app.article-full">Panda Populations Are Growing, But Their Habitat Remains at Risk</a></h2>
         <small>By Jesslyn Shields Oct 3, 2017</small>
       </header>
       <div class="">
@@ -12,7 +12,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Yellowstone Grizzly Bears Lose Endangered Species Protections</a></h2>
+        <h2><a ui-sref="app.article-full">Yellowstone Grizzly Bears Lose Endangered Species Protections</a></h2>
         <small>By Laurie L. Dove Jun 23, 2017</small>
       </header>
       <div class="">
@@ -21,7 +21,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Leopards Have Lost 75 Percent of Historic Range, New Study Finds</a></h2>
+        <h2><a ui-sref="app.article-full">Leopards Have Lost 75 Percent of Historic Range, New Study Finds</a></h2>
         <small>By Christopher Hassiotis May 9, 2016</small>
       </header>
       <div class="">

--- a/src/app/animals/extinct-animals.html
+++ b/src/app/animals/extinct-animals.html
@@ -3,7 +3,7 @@
     <h1>Pets</h1>
     <article class="">
       <header>
-        <h2><a href="#">Prehistoric Frog Had a Monstrous Bite</a></h2>
+        <h2><a ui-sref="app.article-full">Prehistoric Frog Had a Monstrous Bite</a></h2>
         <small>By Mark Mancini Oct 2, 2017</small>
       </header>
       <div class="">
@@ -12,7 +12,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">New Study Sheds Light on How Plesiosaurs Used Their Flippers to Swim</a></h2>
+        <h2><a ui-sref="app.article-full">New Study Sheds Light on How Plesiosaurs Used Their Flippers to Swim</a></h2>
         <small>By Mark Mancini Sep 1, 2017</small>
       </header>
       <div class="">
@@ -21,7 +21,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Why Did the T. Rex Have Such Puny Arms?</a></h2>
+        <h2><a ui-sref="app.article-full">Why Did the T. Rex Have Such Puny Arms?</a></h2>
         <small>Tyrannosaurus rex was a giant predator that roamed the earth, so why did it have such tiny arms?</small>
       </header>
       <div class="">

--- a/src/app/animals/pets.html
+++ b/src/app/animals/pets.html
@@ -3,7 +3,7 @@
     <h1>Pets</h1>
     <article class="">
       <header>
-        <h2><a href="#">Dogs Make More Expressive Faces When Humans Are Watching</a></h2>
+        <h2><a ui-sref="app.article-full">Dogs Make More Expressive Faces When Humans Are Watching</a></h2>
         <small>By Sarah Gleim Oct 23, 2017</small>
       </header>
       <div class="">
@@ -12,7 +12,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Wolves Are Probably Smarter Than Our Dogs</a></h2>
+        <h2><a ui-sref="app.article-wolves">Wolves Are Probably Smarter Than Our Dogs</a></h2>
         <small>By John Perritano Sep 22, 2017</small>
       </header>
       <div class="">
@@ -21,7 +21,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Why Are Cats So Obsessed With Laser Pointers?</a></h2>
+        <h2><a ui-sref="app.article-full">Why Are Cats So Obsessed With Laser Pointers?</a></h2>
         <small>By Jesslyn Shields Dec 13, 2016</small>
       </header>
       <div class="">
@@ -30,7 +30,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">10 Cats Who Made History</a></h2>
+        <h2><a ui-sref="app.article-full">10 Cats Who Made History</a></h2>
         <small>By Melanie Radzicki McManus</small>
       </header>
       <div class="">

--- a/src/app/animals/wild-animals.html
+++ b/src/app/animals/wild-animals.html
@@ -3,7 +3,7 @@
     <h1>Wild Animals</h1>
     <article class="">
       <header>
-        <h2><a href="#">Squirrels Actually Organize Their Nut Hoard — Here's Why</a></h2>
+        <h2><a ui-sref="app.article-full">Squirrels Actually Organize Their Nut Hoard — Here's Why</a></h2>
         <small>By Jamie Allen Sep 28, 2017</small>
       </header>
       <div class="">
@@ -12,7 +12,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">5 Mammals That Are Adorable … and Toxic</a></h2>
+        <h2><a ui-sref="app.article-full">5 Mammals That Are Adorable … and Toxic</a></h2>
         <small>By Kate Kershner Jul 25, 2017</small>
       </header>
       <div class="">
@@ -21,7 +21,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">We Know Far Less About Sharks Than You Might Think</a></h2>
+        <h2><a ui-sref="app.article-sharks">We Know Far Less About Sharks Than You Might Think</a></h2>
         <small>By Jesslyn Shields Aug 24, 2016</small>
       </header>
       <div class="">
@@ -30,7 +30,7 @@
     </article>
     <article class="">
       <header>
-        <h2><a href="#">Do Flying Cockroaches Target Your Face, or Does It Just Feel That Way?</a></h2>
+        <h2><a ui-sref="app.article-full">Do Flying Cockroaches Target Your Face, or Does It Just Feel That Way?</a></h2>
         <small>By Jesslyn Shields Oct 26, 2017</small>
       </header>
       <div class="">

--- a/src/app/menu/menu.html
+++ b/src/app/menu/menu.html
@@ -28,6 +28,6 @@
     </ul>
   </div> -->
 </pf-vertical-navigation>
-<div class="techs container-fluid container-cards-pf container-pf-nav-pf-vertical">
+<div class="techs container-fluid container-cards-pf container-pf-nav-pf-vertical" tabindex="0" id="container">
   <ui-view></ui-view>
 </div>

--- a/src/app/menu/menu.js
+++ b/src/app/menu/menu.js
@@ -4,7 +4,7 @@ module.exports = {
 };
 
 /** @ngInject */
-function TechsController() {
+function TechsController($rootScope, $scope) {
   var vm = this;
 
   vm.navigationItems = [
@@ -94,4 +94,14 @@ function TechsController() {
       ]
     }
   ];
+
+  let listener = $rootScope.$on('$stateChangeSuccess', function () {
+    // eslint-disable-next-line angular/document-service
+    var element = document.getElementById('container');
+    if (element) {
+      element.focus();
+    }
+  });
+
+  $scope.$on('$destroy', listener);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ var angular = require('angular');
 
 var menuModule = require('./app/menu/index');
 require('angular-ui-router');
+require('angular-ui-router/release/stateEvents');
 require('angular-ui-bootstrap');
 
 require('patternfly/dist/js/patternfly-settings');
@@ -19,22 +20,19 @@ var articleFull = require('./app/animals/articleFull');
 var articleWolves = require('./app/animals/articleWolves');
 var articleSharks = require('./app/animals/articleSharks');
 
-
-
-
 require('./index.css');
 require('patternfly/dist/css/patternfly.css');
 require('patternfly/dist/css/patternfly-additions.css');
 
 angular
-  .module('app', [menuModule, 'ui.router', 'patternfly.navigation', 'ui.bootstrap'])
+  .module('app', [menuModule, 'ui.router', 'ui.router.state.events', 'patternfly.navigation', 'ui.bootstrap'])
   .config(routesConfig)
   .component('app', main)
   .component('endangeredSpecies', endangeredSpecies)
   .component('pets', pets)
   .component('extinctAnimals', extinctAnimals)
-  .component('wildAnimals', wildAnimals);
-  .component('articleWolves', articleWolves);
-  .component('articleSharks', articleSharks);
-  .component('articleFull', articleFull);
+  .component('wildAnimals', wildAnimals)
+  .component('articleWolves', articleWolves)
+  .component('articleSharks', articleSharks)
+  .component('articleFull', articleFull)
   .component('articleSummary', articleSummary);

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,22 +25,21 @@ function routesConfig($stateProvider, $urlRouterProvider, $locationProvider) {
     .state('app.dodos', {
       url: 'dodos',
       component: 'extinctAnimals'
-    });
+    })
     .state('app.article-summary', {
       url: 'article-summary',
       component: 'articleSummary'
-    });
+    })
     .state('app.article-full', {
       url: 'article-full',
       component: 'articleFull'
-    });
+    })
     .state('app.article-wolves', {
       url: 'article-wolves',
       component: 'articleWolves'
-    });
+    })
     .state('app.article-sharks', {
       url: 'article-sharks',
       component: 'articleSharks'
     });
-
 }


### PR DESCRIPTION
1. On the page /pets, I'd like the 2nd article to link to /article-wolves
2. On the page /wild-animals, I'd like the 3rd article to link to /article-sharks
3. On the page /article-wolves, I'd like the link "Back to Pets" to link to /pets
4. On the page /article-sharks, I'd like the link "Back to Wild Animals" to link to /wild-animals
5. On all pages that list articles, I'd like the article links to link to /article-full, except for the articles mentioned for #1 and #2 above.
6. In the vertical navigation, when I hit the Enter key to navigate to a page, is it possible to shift focus to either the page contents (e.g. where id="main") or to the beginning of the page? Currently, when I hit the Enter key, I see the page contents change, but the focus is still in the menu. Whereas in the Bootstrap site, when I select a navigation menu item that displays new contents, focus is reset to the beginning of the page
7. In the vertical navigation, when I hit Enter on a primary menu item to display the submenu, the app will also navigate to the page of the first menu item in the submenu. Is it possible to have it not automatically navigate to the first page, or is that part of the current design of the vertical nav?